### PR TITLE
Update life cycle stage

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ title: "Data Harvesting for Agriculture"
 
 # Life cycle stage of the lesson
 # possible values: "pre-alpha", "alpha", "beta", "stable"
-life_cycle: "beta"
+life_cycle: "alpha"
 
 # JPN
 port: 4007


### PR DESCRIPTION
The banner at the top of the lesson pages needs to be made consistent with the life cycle [described in the Carpentries Curriculum Development Handbook](https://cdh.carpentries.org/the-lesson-life-cycle.html). I watched the lightning talk you gave on the subject at CarpentryCon@Home 2020, so I know you've taught this lesson material at least once. That puts the lesson at 'alpha' stage unless it's been taught several times already? In order to fall under 'beta' status, the lesson needs to be ready to be taught by other community members, have been published on Zenodo etc.

For now, I propose to set `life_cycle` to alpha in `_config.yml`, but I would love for us to meet soon so that I can find out more about your plans for the lesson and how I and the rest of the Carpentries core team can help you with the ongoing development.